### PR TITLE
CompatHelper: bump compat for Turing to 0.30, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ MCMCChains = "^6"
 Memoization = "^0.2"
 ReverseDiff = "^1.15"
 StatsBase = "^0.34"
-Turing = "0.29"
+Turing = "0.29, 0.30"
 UnPack = "^1"
 julia = "1"
 


### PR DESCRIPTION
This pull request changes the compat entry for the `Turing` package from `0.29` to `0.29, 0.30`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.